### PR TITLE
changed .so name for stream to streaming

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ endif
 #CFLAGS=-pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS -Wno-system-headers -isystem -g -ggdb3  -D_STDC_LIMIT_MACROS
 CFLAGS=-W -Wextra -Wall -Wno-unused-parameter -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused -fPIC -D_STDC_FORMAT_MACROS -Wno-system-headers -isystem -O3 -g -DNDEBUG -D_STDC_LIMIT_MACROS
 INC=-I. -DPROJECT_ROOT="\"$(SCIDB)\"" -I"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boost/include/" -I"$(SCIDB)/include"
-LIBS=-shared -Wl,-soname,libstream.so -L. -L"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boost/lib" -L"$(SCIDB)/lib" -Wl,-rpath,$(SCIDB)/lib:$(RPATH) -lm
+LIBS=-shared -Wl,-soname,libstreaming.so -L. -L"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boost/lib" -L"$(SCIDB)/lib" -Wl,-rpath,$(SCIDB)/lib:$(RPATH) -lm
 CFLAGS+=-std=c++11 -DCPP11
 
 SRCS=plugin.cpp LogicalStream.cpp PhysicalStream.cpp ChildProcess.cpp TSVInterface.cpp DFInterface.cpp
@@ -40,11 +40,11 @@ else
   endif
 endif
 
-all: libstream.so
+all: libstreaming.so
 	
-libstream.so: $(SRCS) StreamSettings.h ChildProcess.h TSVInterface.h DFInterface.h
+libstreaming.so: $(SRCS) StreamSettings.h ChildProcess.h TSVInterface.h DFInterface.h
 	@if test ! -d "$(SCIDB)"; then echo  "Error. Try:\n\nmake SCIDB=<PATH TO SCIDB INSTALL PATH>"; exit 1; fi
-	$(CXX) $(CFLAGS) $(INC) -o libstream.so $(SRCS) $(LIBS)
+	$(CXX) $(CFLAGS) $(INC) -o libstreaming.so $(SRCS) $(LIBS)
 	@echo "Now copy *.so to your SciDB lib/scidb/plugins directory and run"
 	@echo "iquery -aq \"load_library('stream')\" # to load the plugin."
 	@echo

--- a/src/restart.sh
+++ b/src/restart.sh
@@ -8,11 +8,11 @@ echo "Using scidb at " $SCIDB_BIN
 echo "Using config " $CONFIG_NAME
 
 
-iquery -aq "unload_library('stream')"
+iquery -aq "unload_library('streaming')"
 set -e
 set -x
 make
 scidb.py stopall $CONFIG_NAME
-cp libstream.so $SCIDB_BIN/../lib/scidb/plugins
+cp libstreaming.so $SCIDB_BIN/../lib/scidb/plugins
 scidb.py startall $CONFIG_NAME
-iquery -aq "load_library('stream')"
+iquery -aq "load_library('streaming')"


### PR DESCRIPTION
In the past, I have created scrips that do something like this:

```
# Pseudo-code below
for PLUGIN in accelerated_io_tools summarize limit streaming
do
 iquery -aq "install_github('Paradigm4/$PLUGIN')" 
 iquery -aq "load_library('$PLUGIN')" 
done
```

Because we did not follow the `.so` naming convention here, my script failed while trying to load `streaming` because it found `libstream.so` instead. 

My suggestion would be to try and have the `.so` file always be `lib${GithubRepoHandle}.so`.

I realize this is almost a [nit](http://stackoverflow.com/questions/27810522/what-does-nit-mean-in-hacker-speak), but this kind of uniformity is helpful for writing scripts upstream. 